### PR TITLE
fixed zombie processes

### DIFF
--- a/src/Tomita/TomitaParser.php
+++ b/src/Tomita/TomitaParser.php
@@ -38,6 +38,8 @@ class TomitaParser {
 
             fclose($pipes[1]);
             fclose($pipes[2]);
+            
+            proc_close($process);
 
             return $this->processResult($output);
         }


### PR DESCRIPTION
Если запускать парсер из воркера не закрывать процесс принудительно, то плодятся зомби до тех пор, пока работа воркера не завершится:

```
ps ax | grep "defunct"
16553 ?        Z      0:00 [sh] <defunct>
....
```